### PR TITLE
Removal of 'n1 paper form'

### DIFF
--- a/app/views/prototypes/prototype-may-2018/dashboard/idam/gov/v1/eligibility/result/index.html
+++ b/app/views/prototypes/prototype-may-2018/dashboard/idam/gov/v1/eligibility/result/index.html
@@ -26,7 +26,7 @@ Money Claims Prototype
               {% elif data['a']=="amount-unknown" %}
       <p>You need to know the claim amount to use this service.</p>
 
-      <p>If you can't calculate the claim amount, for example you’re claiming for an injury or accident, use the <a target="_blank" href='http://formfinder.hmctsformfinder.justice.gov.uk/n1-eng.pdf'>N1 paper form</a> <span class="font-xsmall">(opens in a new window)</span>.</p>
+      <p>If you can't calculate the claim amount, for example because you’re claiming for an injury or accident, <a target="_blank" href='http://formfinder.hmctsformfinder.justice.gov.uk/n1-eng.pdf'>download the paper form</a> <span class="font-xsmall">(opens in a new window)</span>. Complete the form and return it to make your claim.</p>
 
       <h3 class="heading-medium">Where to send paper forms</h3>
       <p>County Court Money Claims Centre<br>

--- a/app/views/prototypes/prototype-may-2018/dashboard/idam/gov/v1/overview.html
+++ b/app/views/prototypes/prototype-may-2018/dashboard/idam/gov/v1/overview.html
@@ -44,9 +44,9 @@ Money Claims Prototype
         </div>
         <h2 id="make-a-claim">Make a claim</h2>
         <p><a href="/make-money-claim-online">Make your claim online</a> if you’re claiming for a fixed (‘specified’) amount of money.</p>
-        <p>Download and fill in a paper <a rel="external" href="http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=338">claim form N1</a> if you’re claiming for an unspecified amount of money.</p>
+        <p><a rel="external" href="http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=338">Download a paper form</a> to claim for an unspecified amount of money.</p>
         <p>You can also use the paper claim form to claim for a fixed amount.</p>
-        <p>Send the paper form to the County Court Money Claims Centre.</p>
+        <p>Complete the form and post it to the County Court Money Claims Centre.</p>
         <div class="address"><div class="adr org fn"><p>
           County Court Money Claims Centre
           <br>PO Box 527

--- a/app/views/prototypes/prototype-may-2018/dashboard/idam/gov/v2/eligibility/result/index.html
+++ b/app/views/prototypes/prototype-may-2018/dashboard/idam/gov/v2/eligibility/result/index.html
@@ -15,7 +15,7 @@ Money Claims Prototype
         <p>This service is for claims of £10,000 or less.</p>
       <p>For claims between £10,001 and £100,000 you might be able to <a href="mcol-eligibility"> use Money Claim Online (MCOL)</a>. </p>
 
-        <p>You can also use <a target="_blank" href='http://formfinder.hmctsformfinder.justice.gov.uk/n1-eng.pdf'>form N1</a> <span class="font-xsmall">(opens in a new window)</span>.</p>
+        <p>You can also use <a target="_blank" href='http://formfinder.hmctsformfinder.justice.gov.uk/n1-eng.pdf'>download a paper form</a> <span class="font-xsmall">(opens in a new window)</span>. Complete the form and return it to make your claim.</p>
       <h3 class="heading-medium">Where to send paper forms</h3>
       <p>County Court Money Claims Centre<br>
         PO Box 527<br>
@@ -27,7 +27,7 @@ Money Claims Prototype
               {% elif data['a']=="amount-unknown" %}
       <p>You need to know the claim amount to use this service.</p>
 
-      <p>If you can't calculate the claim amount, for example because you’re claiming for an injury or accident, use the <a target="_blank" href='http://formfinder.hmctsformfinder.justice.gov.uk/n1-eng.pdf'>N1 paper form</a> <span class="font-xsmall">(opens in a new window)</span>.</p>
+      <p>If you can't calculate the claim amount, for example because you’re claiming for an injury or accident, you need to <a target="_blank" href='http://formfinder.hmctsformfinder.justice.gov.uk/n1-eng.pdf'>download a paper form</a> <span class="font-xsmall">(opens in a new window)</span>. Complete the form and return it.</p>
 
       <h3 class="heading-medium">Where to send paper forms</h3>
       <p>County Court Money Claims Centre<br>
@@ -38,8 +38,8 @@ Money Claims Prototype
 
         {% elif data['a']=="claim-multi" %}
 
-        <p>You can't use this service if more than one person or business is making the claim.</p>
-        <p>Use <a target="_blank" href='http://formfinder.hmctsformfinder.justice.gov.uk/n1-eng.pdf'>form N1</a> <span class="font-xsmall">(opens in a new window)</span> to make your claim.</p>
+        <p>You can't use this service if more than one person or organisation is making the claim.</p>
+        <p><a target="_blank" href='http://formfinder.hmctsformfinder.justice.gov.uk/n1-eng.pdf'>Download a paper form</a> <span class="font-xsmall">(opens in a new window)</span>to claim on behalf of more than one person or organisation. Complete the form and return it to make your claim.</p>
       <h3 class="heading-medium">Where to send paper forms</h3>
       <p>County Court Money Claims Centre<br>
         PO Box 527<br>
@@ -49,7 +49,7 @@ Money Claims Prototype
         {% elif data['a']=="def-multi" %}
         <p>You can't use this service if your claim is against more than one person or business.</p>
       Use <a href='https://www.moneyclaim.gov.uk/web/mcol/welcome'>Money Claim Online (MCOL)</a> for claims against 2 people or organisations.</p>
-        <p>Use <a target="_blank" href='http://formfinder.hmctsformfinder.justice.gov.uk/n1-eng.pdf'>form N1</a> <span class="font-xsmall">(opens in a new window)</span> for claims against 3 or more people or organisations.</p>
+        <p>To claim against more than 3 people or organisations <a target="_blank" href='http://formfinder.hmctsformfinder.justice.gov.uk/n1-eng.pdf'>download a paper form</a> <span class="font-xsmall">(opens in a new window).</span>Complete the form and return it to make your claim.</p>
       <h3 class="heading-medium">Where to send paper forms</h3>
       <p>County Court Money Claims Centre<br>
         PO Box 527<br>
@@ -62,7 +62,7 @@ Money Claims Prototype
 
         {% elif data['a']=="d-address" %}
         <p>You can only use this service to claim against a person or organisation with an address in England or Wales.</p>
-      <p>Depending on where you’ll be sending the claim, you might be able to <a target="_blank" href='https://www.moneyclaimsuk.co.uk/PDFForms/N1.pdf'>use form N1</a> (opens in a new window) and <a target="_blank" href='https://www.moneyclaimsuk.co.uk/PDFForms/N510.pdf'>form N510</a><span class="font-xsmall"> (opens in a new window)</span>.</p>
+      <p>Depending on where you’ll be sending the claim, you might be able to claim using a paper form. To claim by paper, <a target="_blank" href='https://www.moneyclaimsuk.co.uk/PDFForms/N1.pdf'>download the paper form N1</a> (opens in a new window) and <a target="_blank" href='https://www.moneyclaimsuk.co.uk/PDFForms/N510.pdf'>form N510</a><span class="font-xsmall"> (opens in a new window)</span>. Complete the forms and return them to make your claim.</p>
       <h3 class="heading-medium">Where to send paper forms</h3>
       <p>County Court Money Claims Centre<br>
         PO Box 527<br>
@@ -80,9 +80,9 @@ Money Claims Prototype
 
               {% elif data['a']=="hwf" %}
            {% if data['version'] == "testing" %}
-              <p>You need to use the paper service if you want help paying your court fees.</p>
+              <p>You need to claim using a paper form if you want help paying your court fees.</p>
               <p><a target="_blank" href="https://sm6gbj.axshare.com/hwf_calculator_start_page.html">Check if you're eligible for help paying your court fees.</a> <span class="font-xsmall">(opens in a new window)</span> </p>
-              <p>If you're eligible for help with fees, make your claim by post using <a target="_blank" href='http://formfinder.hmctsformfinder.justice.gov.uk/n1-eng.pdf'>form N1</a> <span class="font-xsmall">(opens in new window)</span>.</p>
+              <p>If you're eligible for help with fees, make your claim by post. <a target="_blank" href='http://formfinder.hmctsformfinder.justice.gov.uk/n1-eng.pdf'>Download a paper form.</a> <span class="font-xsmall">(opens in new window)</span>. Complete the form and return it to make your claim.</p>
       <h3 class="heading-medium">Where to send paper forms</h3>
       <p>County Court Money Claims Centre<br>
         PO Box 527<br>
@@ -91,8 +91,8 @@ Money Claims Prototype
       </p>
 
               {% else %}
-              <p>You need to use the paper service if you want <a href="https://www.gov.uk/get-help-with-court-fees">help paying your court fees.</a></p>
-            <p>Make your claim by post using <a target="_blank" href='http://formfinder.hmctsformfinder.justice.gov.uk/n1-eng.pdf'>form N1</a> <span class="font-xsmall">(opens in new window)</span>.</p>
+              <p>You need to use a paper form if you want <a href="https://www.gov.uk/get-help-with-court-fees">help paying your court fees.</a></p>
+            <p><a target="_blank" href='http://formfinder.hmctsformfinder.justice.gov.uk/n1-eng.pdf'>Download a paper form</a> <span class="font-xsmall">(opens in new window)</span>. Complete and return the form to make your claim.</p>
       <h3 class="heading-medium">Where to send paper forms</h3>
       <p>County Court Money Claims Centre<br>
         PO Box 527<br>
@@ -112,11 +112,11 @@ Money Claims Prototype
         <p>This service is currently for claimants representing themselves.</p>
         <p>If you're a legal representative <a href='https://www.moneyclaim.gov.uk/web/mcol/welcome'>use the Money Claim Online (MCOL) service</a>.</p>
 
-        <p>Or use <a target="_blank" href='http://formfinder.hmctsformfinder.justice.gov.uk/n1-eng.pdf'>form N1</a> to make your claim.</p>
+        <p>Or <a target="_blank" href='http://formfinder.hmctsformfinder.justice.gov.uk/n1-eng.pdf'>download a paper form</a><span class="font-xsmall">(opens in a new window). Complete and return the form to make your claim.</p>
 
         {% elif data['a']=="crown" %}
       You can't use this service to claim against <a target="_blank" href="https://www.gov.uk/government/publications/serve-the-treasury-solicitor-with-legal-proceedings">government departments</a> <span class="font-xsmall">(opens in a new window)</span>.
-      <p>Use <a target="_blank" href='http://formfinder.hmctsformfinder.justice.gov.uk/n1-eng.pdf'>form N1</a> <span class="font-xsmall">(opens in a new window)</span> to make your claim.</p>
+      <p>To make your claim,<a target="_blank" href='http://formfinder.hmctsformfinder.justice.gov.uk/n1-eng.pdf'>download a paper form</a> <span class="font-xsmall">(opens in a new window)</span>. Complete the form and return it to make your claim.</p>
       <h3 class="heading-medium">Where to send paper forms</h3>
       <p>County Court Money Claims Centre<br>
         PO Box 527<br>

--- a/app/views/prototypes/prototype-may-2018/dashboard/idam/gov/v2/overview.html
+++ b/app/views/prototypes/prototype-may-2018/dashboard/idam/gov/v2/overview.html
@@ -44,7 +44,7 @@ Money Claims Prototype
         </div>
         <h2 id="make-a-claim">Make a claim</h2>
         <p><a href="make-claim">Make your claim online</a> if you’re claiming for a fixed (‘specified’) amount of money.</p>
-        <p>Download and fill in a paper <a rel="external" href="http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=338">claim form N1</a> if you’re claiming for an unspecified amount of money.</p>
+        <p>Download and complete the <a rel="external" href="http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=338">paper claim form</a> if you’re claiming for an unspecified amount of money.</p>
         <p>You can also use the paper claim form to claim for a fixed amount.</p>
         <p>Send the paper form to the County Court Money Claims Centre.</p>
         <div class="address"><div class="adr org fn"><p>


### PR DESCRIPTION
I've removed all reference to the N1 paper form on Marc's instruction. This required a rewording of a lot of ineligibility pages, I also made the links more active and accessible in the process.

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
