### PR TITLE
ROC-4108

### DIFF
--- a/app/views/prototypes/features-to-be-built/claimant/task-list/claim-details/reason/index.html
+++ b/app/views/prototypes/features-to-be-built/claimant/task-list/claim-details/reason/index.html
@@ -21,10 +21,11 @@ Money Claims Prototype
           {% endif %}
           {{formData | safe}}
           <h1 class="heading-large">
-            Why you’re owed the money
+            Briefly explain your claim
           </h1>
-          <div class=""><p>Briefly explain why you believe the defendant owes you money.</p>  </div>
-
+          <p>Tell us why you believe Mary Richards owes you money.</p>
+          <p>Don't give us a detailed timeline - we'll ask for that separately.</p>
+          <p>You'll have to pay an extra fee if you want to change the details of the claim later.</p>
 
           <fieldset>
             <legend class="visuallyhidden">

--- a/app/views/prototypes/features-to-be-built/claimant/task-list/their-details/enter-details/index.html
+++ b/app/views/prototypes/features-to-be-built/claimant/task-list/their-details/enter-details/index.html
@@ -29,6 +29,7 @@ Money Claims Prototype
             <form method="post" action="your-details/date-of-birth" class="form">
               Their details
             </h1>
+            <p>You'll have to pay an extra fee if you later want to change the name of anyone involved with the claim.</p>
             <div class="form-group">
               <label class="form-label" for="defendant_name">Full name (include title)</label>
               <input class="form-control " id="defendant_name" name="defendant_name" type="text"
@@ -47,6 +48,7 @@ Money Claims Prototype
             <h1 class="heading-large">
               Company details
             </h1>
+            <p>You'll have to pay an extra fee if you later want to change the name of a company involved with the claim.</p>
             <fieldset>
               <div class="form-group">
                 <label class="form-label" for="defendant_name">Company name</label>
@@ -68,6 +70,7 @@ Money Claims Prototype
             <h1 class="heading-large">
               Organisation details
             </h1>
+            <p>You'll have to pay an extra fee if you later want to change the name of an organisation involved with the claim.</p>
             <fieldset>
               <div class="form-group">
                 <label class="form-label" for="defendant_name">Organisation name</label>
@@ -90,6 +93,7 @@ Money Claims Prototype
               {% endif %}
               Their details
             </h1>
+            <p>You'll have to pay an extra fee if you later want to change the name of anyone involved with the claim.</p>
             <fieldset>
               <div class="form-group">
                 <label class="form-label" for="defendant_firstname">Full name (include title)</label>

--- a/app/views/prototypes/prototype-oct-2018/claimant/task-list/claim-details/reason/index.html
+++ b/app/views/prototypes/prototype-oct-2018/claimant/task-list/claim-details/reason/index.html
@@ -26,8 +26,8 @@ Money Claims Prototype
           <div class="">
 
             <p>Tell us why you believe {% if data['counterclaim'] %}Jan Clark{% else %}Mary Richards{% endif %} owes you {% if data['counterclaim'] %}£{{ data['counter-amount'] or 500 }}{% else %}money{% endif %}.</p>
-
-            <p>Don't give us a detailed timeline - we'll ask for that later.</p>
+            <p>Don't give us a detailed timeline - we'll ask for that separately.</p>
+            <p>You'll have to pay an extra fee if you want to change the details of the claim later.</p>
 
          </div>
 

--- a/app/views/prototypes/prototype-oct-2018/claimant/task-list/their-details/enter-details/index.html
+++ b/app/views/prototypes/prototype-oct-2018/claimant/task-list/their-details/enter-details/index.html
@@ -29,6 +29,7 @@ Money Claims Prototype
             <form method="post" action="your-details/date-of-birth" class="form">
               Their details
             </h1>
+            <p>You'll have to pay an extra fee if you later want to change the name of anyone involved with the claim.</p>
             <div class="form-group">
               <label class="form-label" for="defendant_name">Full name (include title)</label>
               <input class="form-control " id="defendant_name" name="defendant_name" type="text"
@@ -47,6 +48,7 @@ Money Claims Prototype
             <h1 class="heading-large">
               Company details
             </h1>
+            <p>You'll have to pay an extra fee if you later want to change the name of a company involved with the claim.</p>
             <fieldset>
               <div class="form-group">
                 <label class="form-label" for="defendant_name">Company name</label>
@@ -68,6 +70,7 @@ Money Claims Prototype
             <h1 class="heading-large">
               Organisation details
             </h1>
+            <p>You'll have to pay an extra fee if you later want to change the name of an organisation involved with the claim.</p>
             <fieldset>
               <div class="form-group">
                 <label class="form-label" for="defendant_name">Organisation name</label>
@@ -94,6 +97,7 @@ Money Claims Prototype
               {% endif %}
               Their details
             </h1>
+            <p>You'll have to pay an extra fee if you later want to change the name of anyone involved with the claim.</p>
             <fieldset>
               <div class="form-group">
                 <label class="form-label" for="defendant_firstname">Full name (include title)</label>


### PR DESCRIPTION
Changes to enable the removal of the 'Get your details right' interstitial page

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
