### PR TITLE
content - minor change

### DIFF
--- a/app/views/prototypes/features-to-be-built/dashboard/defendant.html
+++ b/app/views/prototypes/features-to-be-built/dashboard/defendant.html
@@ -769,7 +769,7 @@
                 {% endif %}
 
                 <h2 class="heading-medium">View the claimant's response to the order</h2>
-                <p><a href="order-response/view?party=claimant" class="button secondary-button">See the details they sent the court</a></p>
+                <p><a href="order-response/view?party=claimant" class="button secondary-button">See the details {{ partyName( 'claimant' ) }} sent to the court</a></p>
 
                 {% if data['defendant'] == 12.6 %}
                 <h3 class="heading-small">View the claimant's response to your request to review the order</h3>
@@ -791,7 +791,7 @@
                 <hr />
 
                 <h2 class="heading-medium">View the claimant's response to the order</h2>
-                <p><a href="order-response/view?party=claimant" class="button secondary-button">See the details they sent the court</a></p>
+                <p><a href="order-response/view?party=claimant" class="button secondary-button">See the details {{ partyName( 'claimant' ) }} sent to the court</a></p>
               </div>
 
               {% elseif data['defendant'] == 12.101 %}
@@ -811,7 +811,7 @@
 
                 <hr />
                 <h2 class="heading-medium">View the claimant's response to the order</h2>
-                <p><a href="order-response/view?party=claimant" class="button secondary-button">See the details they sent the court</a></p>
+                <p><a href="order-response/view?party=claimant" class="button secondary-button">See the details {{ partyName( 'claimant' ) }} sent to the court</a></p>
               </div>
 
 
@@ -1035,7 +1035,7 @@
                 <hr />
                 <h2 class="heading-medium">View the responses to the order</h2>
                 <p><a href="order-response/view?party=claimant&view=you" class="button secondary-button">See the details you sent to the court</a></p>
-                <p><a href="order-response/view?party=defendant&view=them" class="button secondary-button">See the details the defendant sent to the court</a></p>
+                <p><a href="order-response/view?party=defendant&view=them" class="button secondary-button">See the details {{ partyName( 'claimant' ) }} sent to the court</a></p>
 
               </div>
 
@@ -1091,7 +1091,7 @@
               <hr />
               <h2 class="heading-medium">View the responses to the order</h2>
               <p><a href="order-response/view?party=defendant&view=you" class="button secondary-button">See the details you sent to the court</a></p>
-              <p><a href="order-response/view?party=claimant&view=them" class="button secondary-button">See the details the claimant sent the court</a></p>
+              <p><a href="order-response/view?party=claimant&view=them" class="button secondary-button">See the details {{ partyName( 'claimant' ) }} sent to the court</a></p>
 
 
 
@@ -1107,7 +1107,7 @@
               <hr />
               <h2 class="heading-medium">View the responses to the order</h2>
               <p><a href="order-response/view?party=defendant&view=you" class="button secondary-button">See the details you sent to the court</a></p>
-              <p><a href="order-response/view?party=claimant&view=them" class="button secondary-button">See the details the claimant sent the court</a></p>
+              <p><a href="order-response/view?party=claimant&view=them" class="button secondary-button">See the details {{ partyName( 'claimant' ) }} sent to the court</a></p>
 
 
 
@@ -1118,7 +1118,7 @@
               <hr />
               <h2 class="heading-medium">View the responses to the order</h2>
               <p><a href="order-response/view?party=defendant&view=you" class="button secondary-button">See the details you sent to the court</a></p>
-              <p><a href="order-response/view?party=claimant&view=them" class="button secondary-button">See the details the claimant sent the court</a></p>
+              <p><a href="order-response/view?party=claimant&view=them" class="button secondary-button">See the details {{ partyName( 'claimant' ) }} sent to the court</a></p>
 
 
 
@@ -1193,7 +1193,7 @@
               <hr />
               <h2 class="heading-medium">View the responses to the order</h2>
               <p><a href="order-response/view?party=defendant&view=you" class="button secondary-button">See the details you sent to the court</a></p>
-              <p><a href="order-response/view?party=claimant&view=them" class="button secondary-button">See the details the claimant sent the court</a></p>
+              <p><a href="order-response/view?party=claimant&view=them" class="button secondary-button">See the details {{ partyName( 'claimant' ) }} sent to the court</a></p>
 
 
 

--- a/app/views/prototypes/prototype-nov-2019/dashboard/defendant.html
+++ b/app/views/prototypes/prototype-nov-2019/dashboard/defendant.html
@@ -1054,7 +1054,7 @@
                 {% endif %}
 
                 <h2 class="heading-medium">View the claimant's response to the order</h2>
-                <p><a href="order-response/view?party=claimant&view=them&done=no" class="button secondary-button">See the details they sent the court</a></p>
+                <p><a href="order-response/view?party=claimant&view=them&done=no" class="button secondary-button">See the details {{ partyName( 'claimant' ) }} sent to the court</a></p>
 
                 {% if data['defendant'] == 12.6 %}
                 <h3 class="heading-small">View the claimant's response to your request to review the order</h3>
@@ -1075,7 +1075,7 @@
                 <hr />
 
                 <h2 class="heading-medium">View the claimant's response to the order</h2>
-                <p><a href="order-response/view?party=claimant&view=them&done=no" class="button secondary-button">See the details they sent the court</a></p>
+                <p><a href="order-response/view?party=claimant&view=them&done=no" class="button secondary-button">See the details {{ partyName( 'claimant' ) }} sent to the court</a></p>
               </div>
 
               {% elseif data['defendant'] == 12.101 %}
@@ -1091,7 +1091,7 @@
 
                 <hr />
                 <h2 class="heading-medium">View the claimant's response to the order</h2>
-                <p><a href="order-response/view?party=claimant&view=them&done=done" class="button secondary-button">See the details they sent the court</a></p>
+                <p><a href="order-response/view?party=claimant&view=them&done=done" class="button secondary-button">See the details {{ partyName( 'claimant' ) }} sent to the court</a></p>
               </div>
 
 
@@ -1337,7 +1337,7 @@
                 <hr />
                 <h2 class="heading-medium">View the responses to the order</h2>
                 <p><a href="order-response/view?party=defendant&view=you&done=done" class="button secondary-button">See the details you sent to the court</a></p>
-                <p><a href="order-response/view?party=claimant&view=them&done=no" class="button secondary-button">See the details the defendant sent to the court</a></p>
+                <p><a href="order-response/view?party=claimant&view=them&done=no" class="button secondary-button">See the details {{ partyName( 'claimant' ) }} sent to the court</a></p>
 
               </div>
 
@@ -1439,7 +1439,7 @@
               <hr />
               <h2 class="heading-medium">View the responses to the order</h2>
               <p><a href="order-response/view?party=defendant&view=you&done=no" class="button secondary-button">See the details you sent to the court</a></p>
-              <p><a href="order-response/view?party=claimant&view=them&done=done" class="button secondary-button">See the details the claimant sent the court</a></p>
+              <p><a href="order-response/view?party=claimant&view=them&done=done" class="button secondary-button">See the details {{ partyName( 'claimant' ) }} sent to the court</a></p>
 
 
 
@@ -1453,7 +1453,7 @@
               <hr />
               <h2 class="heading-medium">View the responses to the order</h2>
               <p><a href="order-response/view?party=defendant&view=you&done=no" class="button secondary-button">See the details you sent to the court</a></p>
-              <p><a href="order-response/view?party=claimant&view=them&done=done" class="button secondary-button">See the details the claimant sent the court</a></p>
+              <p><a href="order-response/view?party=claimant&view=them&done=done" class="button secondary-button">See the details {{ partyName( 'claimant' ) }} sent to the court</a></p>
 
 
 
@@ -1464,7 +1464,7 @@
               <hr />
               <h2 class="heading-medium">View the responses to the order</h2>
               <p><a href="order-response/view?party=defendant&view=you&done=no" class="button secondary-button">See the details you sent to the court</a></p>
-              <p><a href="order-response/view?party=claimant&view=them&done=done" class="button secondary-button">See the details the claimant sent the court</a></p>
+              <p><a href="order-response/view?party=claimant&view=them&done=done" class="button secondary-button">See the details {{ partyName( 'claimant' ) }} sent the court</a></p>
 
 
 
@@ -1557,7 +1557,7 @@
               <hr />
               <h2 class="heading-medium">View the responses to the order</h2>
               <p><a href="order-response/view?party=defendant&view=you&done=no" class="button secondary-button">See the details you sent to the court</a></p>
-              <p><a href="order-response/view?party=claimant&view=them&done=done" class="button secondary-button">See the details the claimant sent the court</a></p>
+              <p><a href="order-response/view?party=claimant&view=them&done=done" class="button secondary-button">See the details {{ partyName( 'claimant' ) }} sent to the court</a></p>
 
 
 


### PR DESCRIPTION
not ticketed but noticed we said see the defendant's response on a link to the claimant's response, in the defendant order response journey. changed all instances of this link to use the claimant's name.

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
